### PR TITLE
Autolearn by time to learn

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -990,7 +990,7 @@ function checkSkillSkipped(skill) {
 }
 
 function setSkillWithLowestMaxXp() {
-    var xpDict = {}
+    var enabledSkills = []
 
     for (skillName in gameData.taskData) {
         var skill = gameData.taskData[skillName]
@@ -1015,17 +1015,19 @@ function setSkillWithLowestMaxXp() {
                 requirement = gameData.requirements["Concentration"];
             }
             if (requirement.isCompleted() && !checkSkillSkipped(skill)) {
-                xpDict[skill.name] = skill.level //skill.getMaxXp() / skill.getXpGain()
+                enabledSkills.push(skill)
             }
         }
     }
 
-    if (xpDict == {}) {
+    if (enabledSkills.length == 0) {
         skillWithLowestMaxXp = gameData.taskData["Concentration"]
         return
     }
+	
+	enabledSkills.sort((lhs, rhs) => { return lhs.getXpLeft() / lhs.getXpGain() - rhs.getXpLeft() / rhs.getXpGain() })
 
-    var skillName = getKeyOfLowestValueFromDict(xpDict)
+    var skillName = enabledSkills[0].name
     skillWithLowestMaxXp = gameData.taskData[skillName]
 }
 


### PR DESCRIPTION
Change autolearn to pick skill by time-left-in-level.  It can be a bit wonky when the autolearn tick happens mid-level, but it should suffice.

Works better with the other PR ("only change skill after level up").